### PR TITLE
NOTICK: Allow more than 50 annotations

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -284,6 +284,7 @@ function main() {
 }
 class TestReporter {
     constructor() {
+        this.maxAnnotationsPerBatch = 50;
         this.artifact = core.getInput('artifact', { required: false });
         this.name = core.getInput('name', { required: true });
         this.path = core.getInput('path', { required: true });
@@ -298,6 +299,19 @@ class TestReporter {
         this.showHTMLNotice = core.getInput('show-html-notice', { required: false }) === 'true';
         this.token = core.getInput('token', { required: true });
         this.context = (0, github_utils_1.getCheckRunContext)();
+        this.handleAnnotations = (annotations, requestParams) => __awaiter(this, void 0, void 0, function* () {
+            const leftAnnotations = [...annotations];
+            let response;
+            do {
+                const toProcess = leftAnnotations.splice(0, 50);
+                const status = leftAnnotations.length > 0 ? 'in_progress' : 'completed';
+                response = yield this.updateAnnotation(toProcess, Object.assign(Object.assign({}, requestParams), { status }));
+            } while (leftAnnotations.length > 0);
+            return response;
+        });
+        this.updateAnnotation = (annotations, requestParams) => __awaiter(this, void 0, void 0, function* () {
+            return yield this.octokit.rest.checks.update(Object.assign(Object.assign({}, requestParams), { output: Object.assign(Object.assign({}, requestParams.output), { annotations }) }));
+        });
         this.octokit = github.getOctokit(this.token);
         if (this.listSuites !== 'all' && this.listSuites !== 'failed') {
             core.setFailed(`Input parameter 'list-suites' has invalid value`);
@@ -307,7 +321,7 @@ class TestReporter {
             core.setFailed(`Input parameter 'list-tests' has invalid value`);
             return;
         }
-        if (isNaN(this.maxAnnotations) || this.maxAnnotations < 0 || this.maxAnnotations > 50) {
+        if (isNaN(this.maxAnnotations) || this.maxAnnotations > 50) {
             core.setFailed(`Input parameter 'max-annotations' has invalid value`);
             return;
         }
@@ -404,7 +418,7 @@ class TestReporter {
             const conclusion = isFailed ? 'failure' : 'success';
             const icon = isFailed ? markdown_utils_1.Icon.fail : markdown_utils_1.Icon.success;
             core.info(`Updating check run conclusion (${conclusion}) and output`);
-            const resp = yield this.octokit.rest.checks.update(Object.assign({ check_run_id: createResp.data.id, conclusion, status: 'completed', output: {
+            const resp = yield this.handleAnnotations(annotations, Object.assign({ check_run_id: createResp.data.id, conclusion, status: 'completed', output: {
                     title: `${name} ${icon}`,
                     summary,
                     annotations

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,11 +235,11 @@ class TestReporter {
   ): Promise<RestEndpointMethodTypes['checks']['update']['response']> => {
     const leftAnnotations = [...annotations]
     let response: RestEndpointMethodTypes['checks']['update']['response']
-    while (leftAnnotations.length > 0) {
+    do {
       const toProcess = leftAnnotations.splice(0, 50)
       const status = leftAnnotations.length > 0 ? 'in_progress' : 'completed'
       response = await this.updateAnnotation(toProcess, {...requestParams, status})
-    }
+    } while (leftAnnotations.length > 0)
     return response
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {GitHub} from '@actions/github/lib/utils'
-import { OctokitResponse } from '@octokit/types'
-import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
 
 import {ArtifactProvider} from './input-providers/artifact-provider'
 import {LocalFileProvider} from './input-providers/local-file-provider'
@@ -10,6 +9,7 @@ import {FileContent} from './input-providers/input-provider'
 import {ParseOptions, TestParser} from './test-parser'
 import {TestRunResult} from './test-results'
 import {getAnnotations, Annotation} from './report/get-annotations'
+import {UpdateChecksParametersWithOutput} from './report/patch-check'
 import {getReport} from './report/get-report'
 
 import {DartJsonParser} from './parsers/dart-json/dart-json-parser'
@@ -231,10 +231,10 @@ class TestReporter {
 
   private handleAnnotations = async (
     annotations: Annotation[],
-    requestParams: RestEndpointMethodTypes['checks']['update']['parameters']
-  ): Promise<Annotation[]> => {
+    requestParams: UpdateChecksParametersWithOutput
+  ): Promise<RestEndpointMethodTypes['checks']['update']['response']> => {
     const leftAnnotations = [...annotations]
-    let response: Promise<RestEndpointMethodTypes['checks']['update']['response']>
+    let response: RestEndpointMethodTypes['checks']['update']['response']
     while (leftAnnotations.length > 0) {
       const toProcess = leftAnnotations.splice(0, 50)
       const status = leftAnnotations.length > 0 ? 'in_progress' : 'completed'
@@ -245,7 +245,7 @@ class TestReporter {
 
   private updateAnnotation = async (
     annotations: Annotation[],
-    requestParams: RestEndpointMethodTypes['checks']['update']['parameters']
+    requestParams: UpdateChecksParametersWithOutput
   ): Promise<RestEndpointMethodTypes['checks']['update']['response']> => {
     return await this.octokit.rest.checks.update({
       ...requestParams,
@@ -253,5 +253,4 @@ class TestReporter {
     })
   }
 }
-
 main()

--- a/src/report/get-annotations.ts
+++ b/src/report/get-annotations.ts
@@ -2,7 +2,7 @@ import {ellipsis, fixEol} from '../utils/markdown-utils'
 import {TestRunResult} from '../test-results'
 import {getFirstNonEmptyLine} from '../utils/parse-utils'
 
-type Annotation = {
+export type Annotation = {
   path: string
   start_line: number
   end_line: number

--- a/src/report/patch-check.ts
+++ b/src/report/patch-check.ts
@@ -1,0 +1,6 @@
+import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
+import {Annotation} from './get-annotations'
+
+export type UpdateChecksParametersWithOutput = RestEndpointMethodTypes['checks']['update']['parameters'] & {
+  output: {title: string; summary: string; annotations: Annotation[]}
+}


### PR DESCRIPTION
Github checks update method fails when more than 50 annotations are provided (more than 50 failed tests)
```No more than 50 items are allowed; 51 were supplied.```
FIxed taking inspiration from
https://github.com/krizzu/eslint-check-action/pull/3/files

**Before this change:**
![Screenshot 2023-12-20 at 16 10 04](https://github.com/hudl/GHA-test-reporter/assets/54805081/d697c31e-bfcb-4272-9315-3104dc83e98b)


[[After this change](reruns: 1)](https://github.com/hudl/hudl-metropole/runs/19822028804)
![image](https://github.com/hudl/GHA-test-reporter/assets/85873825/538c59ce-2290-4ae0-80f9-23044d78814a)
