### PR TITLE
NOTICK | Add option to ignore skipped tests in report

### DIFF
--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -11,12 +11,15 @@ jobs:
     name: Workflow test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check dirs
+        run: ls
+      - name: Test reporter
+        uses: ./
         with:
-          artifact: test-results
           name: Workflow Report
-          path: 'playwright-report.xml'
-          reporter: jest-junit
+          path: playwright-report.xml
+          reporter: java-junit
           show-html-notice: true
           list-suites: 'non-skipped'

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -5,6 +5,7 @@ on:
     workflows: ['CI']
     types:
       - completed
+  push:
 jobs:
   report:
     name: Workflow test

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -19,4 +19,4 @@ jobs:
           path: 'playwright-report.xml'
           reporter: jest-junit
           show-html-notice: true
-          list-suite: non-skipped
+          list-suites: non-skipped

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -19,4 +19,4 @@ jobs:
           path: 'playwright-report.xml'
           reporter: jest-junit
           show-html-notice: true
-          list-suites: non-skipped
+          list-suites: 'non-skipped'

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -22,4 +22,4 @@ jobs:
           path: playwright-report.xml
           reporter: java-junit
           show-html-notice: true
-          list-suites: 'non-skipped'
+          list-tests: 'non-skipped'

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -23,3 +23,4 @@ jobs:
           reporter: java-junit
           show-html-notice: true
           list-tests: 'non-skipped'
+          fail-on-error: false

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -1,0 +1,21 @@
+name: Playwright Test Report
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+jobs:
+  report:
+    name: Workflow test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          artifact: test-results
+          name: Workflow Report
+          path: 'playwright-report.xml'
+          reporter: jest-junit
+          show-html-notice: true
+          list-suite: non-skipped

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ jobs:
     #   all
     #   failed
     #   none
+    #   non-skipped (Only show passed / failed in the file lists)
     list-tests: 'all'
 
     # Limits number of created annotations with error message and stack trace captured during test execution.

--- a/__tests__/__outputs__/playwright-output-all.md
+++ b/__tests__/__outputs__/playwright-output-all.md
@@ -1,0 +1,97 @@
+![Tests failed](https://img.shields.io/badge/tests-36%20passed%2C%204%20failed%2C%2020%20skipped-critical)
+## ❌ <a id="user-content-r0" href="#r0">fixtures/external/java/playwright-report.xml</a>
+**60** tests were completed in **59s** with **36** passed, **4** failed and **20** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[auth.setup.ts](#r0s0)|6✅|||7s|
+|[tests/analyze/load-video.spec.ts](#r0s1)|||3⚪|0ms|
+|[tests/analyze/seamless-video-playback.spec.ts](#r0s2)|||9⚪|12ms|
+|[tests/app.spec.ts](#r0s3)|||1⚪|0ms|
+|[tests/grid.spec.ts](#r0s4)|18✅|4❌|3⚪|116s|
+|[tests/onboarding.spec.ts](#r0s5)|||4⚪|0ms|
+|[tests/statsEngine.spec.ts](#r0s6)|12✅|||36s|
+### ✅ <a id="user-content-r0s0" href="#r0s0">auth.setup.ts</a>
+```
+✅ authenticate as classic admin
+✅ authenticate as basketball admin
+✅ authenticate as wrestling admin
+✅ authenticate as onboarding admin 1
+✅ authenticate as onboarding admin 3
+✅ authenticate as coachAdmin
+```
+### ✅ <a id="user-content-r0s1" href="#r0s1">tests/analyze/load-video.spec.ts</a>
+```
+⚪ record "Time to Video" when loading directly via URL › using manual timings
+⚪ record "Time to Video" when loading directly via URL › using Performance API mark
+⚪ record "Time to Video" when loading directly via URL › using Performance API measurement
+```
+### ✅ <a id="user-content-r0s2" href="#r0s2">tests/analyze/seamless-video-playback.spec.ts</a>
+```
+⚪ during looping playback › when clip repeats, it starts at the beginning
+⚪ during sequential playback ("Play All Clips" mode) › when one clip plays through to the next, overlapping video is skipped
+⚪ in 'Play All Clips' mode, clip plays from beginning › when clicked on in navigation module
+⚪ in 'Play All Clips' mode, clip plays from beginning › with next clip button
+⚪ in 'Play All Clips' mode, clip plays from beginning › with previous clip button
+⚪ in 'Loop Clips' mode, clip plays from beginning › when clicked on in navigation module
+⚪ in 'Loop Clips' mode, clip plays from beginning › with next clip button
+⚪ in 'Loop Clips' mode, clip plays from beginning › with previous clip button
+⚪ rewind functions normally
+```
+### ✅ <a id="user-content-r0s3" href="#r0s3">tests/app.spec.ts</a>
+```
+⚪ App › logs in and loads page
+```
+### ❌ <a id="user-content-r0s4" href="#r0s4">tests/grid.spec.ts</a>
+```
+✅ Grid › Mobile Web › Athlete › should not be able to edit data
+✅ Grid › Mobile Web › Admin or Coach › should be able to edit data
+✅ Grid › Field Sets › should update displayed grid columns after editing
+⚪ Grid › Field Sets › should update displayed clip preview fields after editing
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds
+✅ Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period
+✅ Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts
+❌ Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column
+	[chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order
+⚪ Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column
+⚪ Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach
+❌ Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell
+	[chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data
+	[chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data
+	[chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list
+✅ Grid › Data Entry › should display error state for input with invalid data
+✅ Grid › Data Entry › confirm auto-fill works correctly
+✅ Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Period tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist
+✅ Grid › Tagged data › Wrestling › should edit cells using the team roster
+✅ Grid › Tagged data › Wrestling › should change key moment type and update grid data
+```
+### ✅ <a id="user-content-r0s5" href="#r0s5">tests/onboarding.spec.ts</a>
+```
+⚪ Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt
+⚪ Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt
+⚪ Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt
+⚪ Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt
+```
+### ✅ <a id="user-content-r0s6" href="#r0s6">tests/statsEngine.spec.ts</a>
+```
+✅ Mock stats engine for speed › Filter by Offense in Phase card
+✅ Mock stats engine for speed › Filter by defense in phase card
+✅ Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context
+```

--- a/__tests__/__outputs__/playwright-output-failed.md
+++ b/__tests__/__outputs__/playwright-output-failed.md
@@ -1,0 +1,38 @@
+![Tests failed](https://img.shields.io/badge/tests-36%20passed%2C%204%20failed%2C%2020%20skipped-critical)
+## ❌ <a id="user-content-r0" href="#r0">fixtures/external/java/playwright-report.xml</a>
+**60** tests were completed in **59s** with **36** passed, **4** failed and **20** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[tests/grid.spec.ts](#r0s0)|18✅|4❌|3⚪|116s|
+### ❌ <a id="user-content-r0s0" href="#r0s0">tests/grid.spec.ts</a>
+```
+✅ Grid › Mobile Web › Athlete › should not be able to edit data
+✅ Grid › Mobile Web › Admin or Coach › should be able to edit data
+✅ Grid › Field Sets › should update displayed grid columns after editing
+⚪ Grid › Field Sets › should update displayed clip preview fields after editing
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds
+✅ Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period
+✅ Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts
+❌ Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column
+	[chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order
+⚪ Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column
+⚪ Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach
+❌ Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell
+	[chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data
+	[chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data
+	[chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list
+✅ Grid › Data Entry › should display error state for input with invalid data
+✅ Grid › Data Entry › confirm auto-fill works correctly
+✅ Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Period tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist
+✅ Grid › Tagged data › Wrestling › should edit cells using the team roster
+✅ Grid › Tagged data › Wrestling › should change key moment type and update grid data
+```

--- a/__tests__/__outputs__/playwright-output-no-skipped.md
+++ b/__tests__/__outputs__/playwright-output-no-skipped.md
@@ -1,0 +1,77 @@
+![Tests failed](https://img.shields.io/badge/tests-36%20passed%2C%204%20failed%2C%2020%20skipped-critical)
+## ❌ <a id="user-content-r0" href="#r0">fixtures/external/java/playwright-report.xml</a>
+**60** tests were completed in **59s** with **36** passed, **4** failed and **20** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[auth.setup.ts](#r0s0)|6✅|||7s|
+|[tests/analyze/load-video.spec.ts](#r0s1)|||3⚪|0ms|
+|[tests/analyze/seamless-video-playback.spec.ts](#r0s2)|||9⚪|12ms|
+|[tests/app.spec.ts](#r0s3)|||1⚪|0ms|
+|[tests/grid.spec.ts](#r0s4)|18✅|4❌|3⚪|116s|
+|[tests/onboarding.spec.ts](#r0s5)|||4⚪|0ms|
+|[tests/statsEngine.spec.ts](#r0s6)|12✅|||36s|
+### ✅ <a id="user-content-r0s0" href="#r0s0">auth.setup.ts</a>
+```
+✅ authenticate as classic admin
+✅ authenticate as basketball admin
+✅ authenticate as wrestling admin
+✅ authenticate as onboarding admin 1
+✅ authenticate as onboarding admin 3
+✅ authenticate as coachAdmin
+```
+### ✅ <a id="user-content-r0s1" href="#r0s1">tests/analyze/load-video.spec.ts</a>
+```
+```
+### ✅ <a id="user-content-r0s2" href="#r0s2">tests/analyze/seamless-video-playback.spec.ts</a>
+```
+```
+### ✅ <a id="user-content-r0s3" href="#r0s3">tests/app.spec.ts</a>
+```
+```
+### ❌ <a id="user-content-r0s4" href="#r0s4">tests/grid.spec.ts</a>
+```
+✅ Grid › Mobile Web › Athlete › should not be able to edit data
+✅ Grid › Mobile Web › Admin or Coach › should be able to edit data
+✅ Grid › Field Sets › should update displayed grid columns after editing
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds
+✅ Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period
+✅ Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts
+❌ Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column
+	[chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order
+❌ Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell
+	[chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data
+	[chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data
+	[chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list
+✅ Grid › Data Entry › should display error state for input with invalid data
+✅ Grid › Data Entry › confirm auto-fill works correctly
+✅ Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Period tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist
+✅ Grid › Tagged data › Wrestling › should edit cells using the team roster
+✅ Grid › Tagged data › Wrestling › should change key moment type and update grid data
+```
+### ✅ <a id="user-content-r0s5" href="#r0s5">tests/onboarding.spec.ts</a>
+```
+```
+### ✅ <a id="user-content-r0s6" href="#r0s6">tests/statsEngine.spec.ts</a>
+```
+✅ Mock stats engine for speed › Filter by Offense in Phase card
+✅ Mock stats engine for speed › Filter by defense in phase card
+✅ Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context
+```

--- a/__tests__/__outputs__/playwright-output-summary.md
+++ b/__tests__/__outputs__/playwright-output-summary.md
@@ -1,0 +1,4 @@
+![Tests failed](https://img.shields.io/badge/tests-36%20passed%2C%204%20failed%2C%2020%20skipped-critical)
+|Report|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[fixtures/external/java/playwright-report.xml](#r0)|36✅|4❌|20⚪|59s|

--- a/__tests__/__outputs__/playwright-output.md
+++ b/__tests__/__outputs__/playwright-output.md
@@ -1,0 +1,97 @@
+![Tests failed](https://img.shields.io/badge/tests-36%20passed%2C%204%20failed%2C%2020%20skipped-critical)
+## ❌ <a id="user-content-r0" href="#r0">fixtures/external/java/playwright-report.xml</a>
+**60** tests were completed in **59s** with **36** passed, **4** failed and **20** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[auth.setup.ts](#r0s0)|6✅|||7s|
+|[tests/analyze/load-video.spec.ts](#r0s1)|||3⚪|0ms|
+|[tests/analyze/seamless-video-playback.spec.ts](#r0s2)|||9⚪|12ms|
+|[tests/app.spec.ts](#r0s3)|||1⚪|0ms|
+|[tests/grid.spec.ts](#r0s4)|18✅|4❌|3⚪|116s|
+|[tests/onboarding.spec.ts](#r0s5)|||4⚪|0ms|
+|[tests/statsEngine.spec.ts](#r0s6)|12✅|||36s|
+### ✅ <a id="user-content-r0s0" href="#r0s0">auth.setup.ts</a>
+```
+✅ authenticate as classic admin
+✅ authenticate as basketball admin
+✅ authenticate as wrestling admin
+✅ authenticate as onboarding admin 1
+✅ authenticate as onboarding admin 3
+✅ authenticate as coachAdmin
+```
+### ✅ <a id="user-content-r0s1" href="#r0s1">tests/analyze/load-video.spec.ts</a>
+```
+⚪ record "Time to Video" when loading directly via URL › using manual timings
+⚪ record "Time to Video" when loading directly via URL › using Performance API mark
+⚪ record "Time to Video" when loading directly via URL › using Performance API measurement
+```
+### ✅ <a id="user-content-r0s2" href="#r0s2">tests/analyze/seamless-video-playback.spec.ts</a>
+```
+⚪ during looping playback › when clip repeats, it starts at the beginning
+⚪ during sequential playback ("Play All Clips" mode) › when one clip plays through to the next, overlapping video is skipped
+⚪ in 'Play All Clips' mode, clip plays from beginning › when clicked on in navigation module
+⚪ in 'Play All Clips' mode, clip plays from beginning › with next clip button
+⚪ in 'Play All Clips' mode, clip plays from beginning › with previous clip button
+⚪ in 'Loop Clips' mode, clip plays from beginning › when clicked on in navigation module
+⚪ in 'Loop Clips' mode, clip plays from beginning › with next clip button
+⚪ in 'Loop Clips' mode, clip plays from beginning › with previous clip button
+⚪ rewind functions normally
+```
+### ✅ <a id="user-content-r0s3" href="#r0s3">tests/app.spec.ts</a>
+```
+⚪ App › logs in and loads page
+```
+### ❌ <a id="user-content-r0s4" href="#r0s4">tests/grid.spec.ts</a>
+```
+✅ Grid › Mobile Web › Athlete › should not be able to edit data
+✅ Grid › Mobile Web › Admin or Coach › should be able to edit data
+✅ Grid › Field Sets › should update displayed grid columns after editing
+⚪ Grid › Field Sets › should update displayed clip preview fields after editing
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds
+✅ Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period
+✅ Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers
+✅ Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts
+❌ Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column
+	[chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order
+⚪ Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column
+⚪ Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach
+❌ Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell
+	[chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data
+	[chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3
+❌ Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data
+	[chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list
+✅ Grid › Data Entry › should display error state for input with invalid data
+✅ Grid › Data Entry › confirm auto-fill works correctly
+✅ Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Period tagged from Assist
+✅ Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist
+✅ Grid › Tagged data › Wrestling › should edit cells using the team roster
+✅ Grid › Tagged data › Wrestling › should change key moment type and update grid data
+```
+### ✅ <a id="user-content-r0s5" href="#r0s5">tests/onboarding.spec.ts</a>
+```
+⚪ Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt
+⚪ Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt
+⚪ Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt
+⚪ Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt
+```
+### ✅ <a id="user-content-r0s6" href="#r0s6">tests/statsEngine.spec.ts</a>
+```
+✅ Mock stats engine for speed › Filter by Offense in Phase card
+✅ Mock stats engine for speed › Filter by defense in phase card
+✅ Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context
+✅ Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context
+```

--- a/__tests__/__snapshots__/java-junit.test.ts.snap
+++ b/__tests__/__snapshots__/java-junit.test.ts.snap
@@ -1,5 +1,2525 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`java-junit tests playwright test report - all tests 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/playwright-report.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as classic admin",
+              "result": "success",
+              "time": 1702,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as basketball admin",
+              "result": "success",
+              "time": 1734,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as wrestling admin",
+              "result": "success",
+              "time": 1697,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 1",
+              "result": "success",
+              "time": 516,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 3",
+              "result": "success",
+              "time": 527,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as coachAdmin",
+              "result": "success",
+              "time": 526,
+            },
+          ],
+        },
+      ],
+      "name": "auth.setup.ts",
+      "totalTime": 6702,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using manual timings",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API mark",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API measurement",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/load-video.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "during looping playback › when clip repeats, it starts at the beginning",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "during sequential playback (\\"Play All Clips\\" mode) › when one clip plays through to the next, overlapping video is skipped",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "rewind functions normally",
+              "result": "skipped",
+              "time": 12,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/seamless-video-playback.spec.ts",
+      "totalTime": 12,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "App › logs in and loads page",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/app.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Athlete › should not be able to edit data",
+              "result": "success",
+              "time": 2968,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Admin or Coach › should be able to edit data",
+              "result": "success",
+              "time": 5762,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed grid columns after editing",
+              "result": "success",
+              "time": 9215,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed clip preview fields after editing",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points",
+              "result": "success",
+              "time": 3150,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds",
+              "result": "success",
+              "time": 5091,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals",
+              "result": "success",
+              "time": 4261,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds",
+              "result": "success",
+              "time": 2860,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period",
+              "result": "success",
+              "time": 3501,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers",
+              "result": "success",
+              "time": 3721,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts",
+              "result": "success",
+              "time": 3282,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id^=\\"column-header-OFF FORM-\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/table.locator.ts:12
+
+      10 |     const expectedColumnSort = this.locator.filter({ has: this.page.locator(\`[data-qa-id*='\${sortOrder}']\`) });
+      11 |     do {
+    > 12 |       await this.locator.click();
+         |                          ^
+      13 |     } while (!expectedColumnSort.isVisible());
+      14 |   }
+      15 | }
+
+        at TableLocator.sortColumnBy (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/table.locator.ts:12:26)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:30:52
+        at GridActions.sortColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:28:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:205:27
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/table.locator.ts:12:26
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:256:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:263:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id=\\"clip-edit-field-OFF FORM\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13
+
+      11 |
+      12 |   async click(force: boolean = false) {
+    > 13 |     await this.locator.click({ force });
+         |                        ^
+      14 |   }
+      15 |
+      16 |   async doubleClick() {
+
+        at SelectLocator.click (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:93:58
+        at GridActions.enterGridSelectValue (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:92:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:279:25
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › should display error state for input with invalid data",
+              "result": "success",
+              "time": 5853,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › confirm auto-fill works correctly",
+              "result": "success",
+              "time": 5021,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist",
+              "result": "success",
+              "time": 2522,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist",
+              "result": "success",
+              "time": 2655,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Period tagged from Assist",
+              "result": "success",
+              "time": 2666,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist",
+              "result": "success",
+              "time": 2908,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should edit cells using the team roster",
+              "result": "success",
+              "time": 4794,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should change key moment type and update grid data",
+              "result": "success",
+              "time": 5662,
+            },
+          ],
+        },
+      ],
+      "name": "tests/grid.spec.ts",
+      "totalTime": 115892,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/onboarding.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by Offense in Phase card",
+              "result": "success",
+              "time": 3542,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by defense in phase card",
+              "result": "success",
+              "time": 2471,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected",
+              "result": "success",
+              "time": 3207,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context",
+              "result": "success",
+              "time": 2932,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context",
+              "result": "success",
+              "time": 3549,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2802,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context",
+              "result": "success",
+              "time": 2949,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2937,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context",
+              "result": "success",
+              "time": 3277,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context",
+              "result": "success",
+              "time": 2799,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context",
+              "result": "success",
+              "time": 3056,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context",
+              "result": "success",
+              "time": 2850,
+            },
+          ],
+        },
+      ],
+      "name": "tests/statsEngine.spec.ts",
+      "totalTime": 36371,
+    },
+  ],
+  "totalTime": 59092.58599999547,
+}
+`;
+
+exports[`java-junit tests playwright test report - ignore skipped tests 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/playwright-report.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as classic admin",
+              "result": "success",
+              "time": 1702,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as basketball admin",
+              "result": "success",
+              "time": 1734,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as wrestling admin",
+              "result": "success",
+              "time": 1697,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 1",
+              "result": "success",
+              "time": 516,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 3",
+              "result": "success",
+              "time": 527,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as coachAdmin",
+              "result": "success",
+              "time": 526,
+            },
+          ],
+        },
+      ],
+      "name": "auth.setup.ts",
+      "totalTime": 6702,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using manual timings",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API mark",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API measurement",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/load-video.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "during looping playback › when clip repeats, it starts at the beginning",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "during sequential playback (\\"Play All Clips\\" mode) › when one clip plays through to the next, overlapping video is skipped",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "rewind functions normally",
+              "result": "skipped",
+              "time": 12,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/seamless-video-playback.spec.ts",
+      "totalTime": 12,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "App › logs in and loads page",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/app.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Athlete › should not be able to edit data",
+              "result": "success",
+              "time": 2968,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Admin or Coach › should be able to edit data",
+              "result": "success",
+              "time": 5762,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed grid columns after editing",
+              "result": "success",
+              "time": 9215,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed clip preview fields after editing",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points",
+              "result": "success",
+              "time": 3150,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds",
+              "result": "success",
+              "time": 5091,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals",
+              "result": "success",
+              "time": 4261,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds",
+              "result": "success",
+              "time": 2860,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period",
+              "result": "success",
+              "time": 3501,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers",
+              "result": "success",
+              "time": 3721,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts",
+              "result": "success",
+              "time": 3282,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id^=\\"column-header-OFF FORM-\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/table.locator.ts:12
+
+      10 |     const expectedColumnSort = this.locator.filter({ has: this.page.locator(\`[data-qa-id*='\${sortOrder}']\`) });
+      11 |     do {
+    > 12 |       await this.locator.click();
+         |                          ^
+      13 |     } while (!expectedColumnSort.isVisible());
+      14 |   }
+      15 | }
+
+        at TableLocator.sortColumnBy (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/table.locator.ts:12:26)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:30:52
+        at GridActions.sortColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:28:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:205:27
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/table.locator.ts:12:26
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:256:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:263:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id=\\"clip-edit-field-OFF FORM\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13
+
+      11 |
+      12 |   async click(force: boolean = false) {
+    > 13 |     await this.locator.click({ force });
+         |                        ^
+      14 |   }
+      15 |
+      16 |   async doubleClick() {
+
+        at SelectLocator.click (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:93:58
+        at GridActions.enterGridSelectValue (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:92:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:279:25
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › should display error state for input with invalid data",
+              "result": "success",
+              "time": 5853,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › confirm auto-fill works correctly",
+              "result": "success",
+              "time": 5021,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist",
+              "result": "success",
+              "time": 2522,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist",
+              "result": "success",
+              "time": 2655,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Period tagged from Assist",
+              "result": "success",
+              "time": 2666,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist",
+              "result": "success",
+              "time": 2908,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should edit cells using the team roster",
+              "result": "success",
+              "time": 4794,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should change key moment type and update grid data",
+              "result": "success",
+              "time": 5662,
+            },
+          ],
+        },
+      ],
+      "name": "tests/grid.spec.ts",
+      "totalTime": 115892,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/onboarding.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by Offense in Phase card",
+              "result": "success",
+              "time": 3542,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by defense in phase card",
+              "result": "success",
+              "time": 2471,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected",
+              "result": "success",
+              "time": 3207,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context",
+              "result": "success",
+              "time": 2932,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context",
+              "result": "success",
+              "time": 3549,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2802,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context",
+              "result": "success",
+              "time": 2949,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2937,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context",
+              "result": "success",
+              "time": 3277,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context",
+              "result": "success",
+              "time": 2799,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context",
+              "result": "success",
+              "time": 3056,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context",
+              "result": "success",
+              "time": 2850,
+            },
+          ],
+        },
+      ],
+      "name": "tests/statsEngine.spec.ts",
+      "totalTime": 36371,
+    },
+  ],
+  "totalTime": 59092.58599999547,
+}
+`;
+
+exports[`java-junit tests playwright test report - only failed 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/playwright-report.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as classic admin",
+              "result": "success",
+              "time": 1702,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as basketball admin",
+              "result": "success",
+              "time": 1734,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as wrestling admin",
+              "result": "success",
+              "time": 1697,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 1",
+              "result": "success",
+              "time": 516,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 3",
+              "result": "success",
+              "time": 527,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as coachAdmin",
+              "result": "success",
+              "time": 526,
+            },
+          ],
+        },
+      ],
+      "name": "auth.setup.ts",
+      "totalTime": 6702,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using manual timings",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API mark",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API measurement",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/load-video.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "during looping playback › when clip repeats, it starts at the beginning",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "during sequential playback (\\"Play All Clips\\" mode) › when one clip plays through to the next, overlapping video is skipped",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "rewind functions normally",
+              "result": "skipped",
+              "time": 12,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/seamless-video-playback.spec.ts",
+      "totalTime": 12,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "App › logs in and loads page",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/app.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Athlete › should not be able to edit data",
+              "result": "success",
+              "time": 2968,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Admin or Coach › should be able to edit data",
+              "result": "success",
+              "time": 5762,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed grid columns after editing",
+              "result": "success",
+              "time": 9215,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed clip preview fields after editing",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points",
+              "result": "success",
+              "time": 3150,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds",
+              "result": "success",
+              "time": 5091,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals",
+              "result": "success",
+              "time": 4261,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds",
+              "result": "success",
+              "time": 2860,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period",
+              "result": "success",
+              "time": 3501,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers",
+              "result": "success",
+              "time": 3721,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts",
+              "result": "success",
+              "time": 3282,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id^=\\"column-header-OFF FORM-\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/table.locator.ts:12
+
+      10 |     const expectedColumnSort = this.locator.filter({ has: this.page.locator(\`[data-qa-id*='\${sortOrder}']\`) });
+      11 |     do {
+    > 12 |       await this.locator.click();
+         |                          ^
+      13 |     } while (!expectedColumnSort.isVisible());
+      14 |   }
+      15 | }
+
+        at TableLocator.sortColumnBy (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/table.locator.ts:12:26)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:30:52
+        at GridActions.sortColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:28:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:205:27
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/table.locator.ts:12:26
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:256:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:263:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id=\\"clip-edit-field-OFF FORM\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13
+
+      11 |
+      12 |   async click(force: boolean = false) {
+    > 13 |     await this.locator.click({ force });
+         |                        ^
+      14 |   }
+      15 |
+      16 |   async doubleClick() {
+
+        at SelectLocator.click (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:93:58
+        at GridActions.enterGridSelectValue (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:92:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:279:25
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › should display error state for input with invalid data",
+              "result": "success",
+              "time": 5853,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › confirm auto-fill works correctly",
+              "result": "success",
+              "time": 5021,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist",
+              "result": "success",
+              "time": 2522,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist",
+              "result": "success",
+              "time": 2655,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Period tagged from Assist",
+              "result": "success",
+              "time": 2666,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist",
+              "result": "success",
+              "time": 2908,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should edit cells using the team roster",
+              "result": "success",
+              "time": 4794,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should change key moment type and update grid data",
+              "result": "success",
+              "time": 5662,
+            },
+          ],
+        },
+      ],
+      "name": "tests/grid.spec.ts",
+      "totalTime": 115892,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/onboarding.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by Offense in Phase card",
+              "result": "success",
+              "time": 3542,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by defense in phase card",
+              "result": "success",
+              "time": 2471,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected",
+              "result": "success",
+              "time": 3207,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context",
+              "result": "success",
+              "time": 2932,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context",
+              "result": "success",
+              "time": 3549,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2802,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context",
+              "result": "success",
+              "time": 2949,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2937,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context",
+              "result": "success",
+              "time": 3277,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context",
+              "result": "success",
+              "time": 2799,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context",
+              "result": "success",
+              "time": 3056,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context",
+              "result": "success",
+              "time": 2850,
+            },
+          ],
+        },
+      ],
+      "name": "tests/statsEngine.spec.ts",
+      "totalTime": 36371,
+    },
+  ],
+  "totalTime": 59092.58599999547,
+}
+`;
+
+exports[`java-junit tests playwright test report - only summary 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/playwright-report.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as classic admin",
+              "result": "success",
+              "time": 1702,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as basketball admin",
+              "result": "success",
+              "time": 1734,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as wrestling admin",
+              "result": "success",
+              "time": 1697,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 1",
+              "result": "success",
+              "time": 516,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as onboarding admin 3",
+              "result": "success",
+              "time": 527,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "authenticate as coachAdmin",
+              "result": "success",
+              "time": 526,
+            },
+          ],
+        },
+      ],
+      "name": "auth.setup.ts",
+      "totalTime": 6702,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using manual timings",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API mark",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "record \\"Time to Video\\" when loading directly via URL › using Performance API measurement",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/load-video.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "during looping playback › when clip repeats, it starts at the beginning",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "during sequential playback (\\"Play All Clips\\" mode) › when one clip plays through to the next, overlapping video is skipped",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Play All Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › when clicked on in navigation module",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with next clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "in 'Loop Clips' mode, clip plays from beginning › with previous clip button",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "rewind functions normally",
+              "result": "skipped",
+              "time": 12,
+            },
+          ],
+        },
+      ],
+      "name": "tests/analyze/seamless-video-playback.spec.ts",
+      "totalTime": 12,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "App › logs in and loads page",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/app.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Athlete › should not be able to edit data",
+              "result": "success",
+              "time": 2968,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Mobile Web › Admin or Coach › should be able to edit data",
+              "result": "success",
+              "time": 5762,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed grid columns after editing",
+              "result": "success",
+              "time": 9215,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Field Sets › should update displayed clip preview fields after editing",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points",
+              "result": "success",
+              "time": 3150,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds",
+              "result": "success",
+              "time": 5091,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals",
+              "result": "success",
+              "time": 4261,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds",
+              "result": "success",
+              "time": 2860,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period",
+              "result": "success",
+              "time": 3501,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers",
+              "result": "success",
+              "time": 3721,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts",
+              "result": "success",
+              "time": 3282,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id^=\\"column-header-OFF FORM-\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/table.locator.ts:12
+
+      10 |     const expectedColumnSort = this.locator.filter({ has: this.page.locator(\`[data-qa-id*='\${sortOrder}']\`) });
+      11 |     do {
+    > 12 |       await this.locator.click();
+         |                          ^
+      13 |     } while (!expectedColumnSort.isVisible());
+      14 |   }
+      15 | }
+
+        at TableLocator.sortColumnBy (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/table.locator.ts:12:26)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:30:52
+        at GridActions.sortColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:28:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:205:27
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/table.locator.ts:12:26
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:256:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\\\\'OFF FORM-column-3\\\\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:263:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "
+  [chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id=\\"clip-edit-field-OFF FORM\\"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13
+
+      11 |
+      12 |   async click(force: boolean = false) {
+    > 13 |     await this.locator.click({ force });
+         |                        ^
+      14 |   }
+      15 |
+      16 |   async doubleClick() {
+
+        at SelectLocator.click (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:93:58
+        at GridActions.enterGridSelectValue (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:92:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:279:25
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+",
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data",
+              "result": "failed",
+              "time": 10000,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › should display error state for input with invalid data",
+              "result": "success",
+              "time": 5853,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Data Entry › confirm auto-fill works correctly",
+              "result": "success",
+              "time": 5021,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist",
+              "result": "success",
+              "time": 2522,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist",
+              "result": "success",
+              "time": 2655,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Period tagged from Assist",
+              "result": "success",
+              "time": 2666,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist",
+              "result": "success",
+              "time": 2908,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should edit cells using the team roster",
+              "result": "success",
+              "time": 4794,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Tagged data › Wrestling › should change key moment type and update grid data",
+              "result": "success",
+              "time": 5662,
+            },
+          ],
+        },
+      ],
+      "name": "tests/grid.spec.ts",
+      "totalTime": 115892,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt",
+              "result": "skipped",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "tests/onboarding.spec.ts",
+      "totalTime": 0,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by Offense in Phase card",
+              "result": "success",
+              "time": 3542,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Filter by defense in phase card",
+              "result": "success",
+              "time": 2471,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected",
+              "result": "success",
+              "time": 3207,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context",
+              "result": "success",
+              "time": 2932,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context",
+              "result": "success",
+              "time": 3549,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2802,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context",
+              "result": "success",
+              "time": 2949,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context",
+              "result": "success",
+              "time": 2937,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context",
+              "result": "success",
+              "time": 3277,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context",
+              "result": "success",
+              "time": 2799,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context",
+              "result": "success",
+              "time": 3056,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context",
+              "result": "success",
+              "time": 2850,
+            },
+          ],
+        },
+      ],
+      "name": "tests/statsEngine.spec.ts",
+      "totalTime": 36371,
+    },
+  ],
+  "totalTime": 59092.58599999547,
+}
+`;
+
 exports[`java-junit tests report from apache/pulsar single suite test results matches snapshot 1`] = `
 TestRunResult {
   "path": "fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml",

--- a/__tests__/fixtures/external/java/playwright-report.xml
+++ b/__tests__/fixtures/external/java/playwright-report.xml
@@ -1,0 +1,472 @@
+<testsuites id="" name="" tests="60" failures="4" skipped="20" errors="0" time="59.09258599999547">
+<testsuite name="auth.setup.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="setup" tests="6" failures="0" skipped="0" time="6.702" errors="0">
+<testcase name="authenticate as classic admin" classname="auth.setup.ts" time="1.702">
+</testcase>
+<testcase name="authenticate as basketball admin" classname="auth.setup.ts" time="1.734">
+</testcase>
+<testcase name="authenticate as wrestling admin" classname="auth.setup.ts" time="1.697">
+</testcase>
+<testcase name="authenticate as onboarding admin 1" classname="auth.setup.ts" time="0.516">
+</testcase>
+<testcase name="authenticate as onboarding admin 3" classname="auth.setup.ts" time="0.527">
+</testcase>
+<testcase name="authenticate as coachAdmin" classname="auth.setup.ts" time="0.526">
+</testcase>
+</testsuite>
+<testsuite name="tests/analyze/load-video.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="3" failures="0" skipped="3" time="0" errors="0">
+<testcase name="record &quot;Time to Video&quot; when loading directly via URL › using manual timings" classname="tests/analyze/load-video.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="record &quot;Time to Video&quot; when loading directly via URL › using Performance API mark" classname="tests/analyze/load-video.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="record &quot;Time to Video&quot; when loading directly via URL › using Performance API measurement" classname="tests/analyze/load-video.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/analyze/seamless-video-playback.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="9" failures="0" skipped="9" time="0.012" errors="0">
+<testcase name="during looping playback › when clip repeats, it starts at the beginning" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="during sequential playback (&quot;Play All Clips&quot; mode) › when one clip plays through to the next, overlapping video is skipped" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Play All Clips&apos; mode, clip plays from beginning › when clicked on in navigation module" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Play All Clips&apos; mode, clip plays from beginning › with next clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Play All Clips&apos; mode, clip plays from beginning › with previous clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Loop Clips&apos; mode, clip plays from beginning › when clicked on in navigation module" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Loop Clips&apos; mode, clip plays from beginning › with next clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Loop Clips&apos; mode, clip plays from beginning › with previous clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="rewind functions normally" classname="tests/analyze/seamless-video-playback.spec.ts" time="0.012">
+<properties>
+<property name="slow" value="">
+</property>
+<property name="slow" value="">
+</property>
+<property name="fixme" value="Implement">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/app.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="1" failures="0" skipped="1" time="0" errors="0">
+<testcase name="App › logs in and loads page" classname="tests/app.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/grid.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="25" failures="4" skipped="3" time="115.892" errors="0">
+<testcase name="Grid › Mobile Web › Athlete › should not be able to edit data" classname="tests/grid.spec.ts" time="2.968">
+</testcase>
+<testcase name="Grid › Mobile Web › Admin or Coach › should be able to edit data" classname="tests/grid.spec.ts" time="5.762">
+</testcase>
+<testcase name="Grid › Field Sets › should update displayed grid columns after editing" classname="tests/grid.spec.ts" time="9.215">
+</testcase>
+<testcase name="Grid › Field Sets › should update displayed clip preview fields after editing" classname="tests/grid.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points" classname="tests/grid.spec.ts" time="3.15">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds" classname="tests/grid.spec.ts" time="5.091">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals" classname="tests/grid.spec.ts" time="4.261">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds" classname="tests/grid.spec.ts" time="2.86">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period" classname="tests/grid.spec.ts" time="3.501">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers" classname="tests/grid.spec.ts" time="3.721">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts" classname="tests/grid.spec.ts" time="3.282">
+</testcase>
+<testcase name="Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:202:11 should display correct data when sorting by OFF FORM column" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id^="column-header-OFF FORM-"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/table.locator.ts:12
+
+      10 |     const expectedColumnSort = this.locator.filter({ has: this.page.locator(`[data-qa-id*='${sortOrder}']`) });
+      11 |     do {
+    > 12 |       await this.locator.click();
+         |                          ^
+      13 |     } while (!expectedColumnSort.isVisible());
+      14 |   }
+      15 | }
+
+        at TableLocator.sortColumnBy (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/table.locator.ts:12:26)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:30:52
+        at GridActions.sortColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:28:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:205:27
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/table.locator.ts:12:26
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column" classname="tests/grid.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach" classname="tests/grid.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:254:9 should open select dropdown options when pressing Spacebar in grid cell" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\'OFF FORM-column-3\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:256:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:261:9 should be able to use keyboard to navigate horizontal grid and enter data" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\'OFF FORM-column-3\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:263:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:277:9 should be able to use keyboard to navigate vertical grid and enter data" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id="clip-edit-field-OFF FORM"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13
+
+      11 |
+      12 |   async click(force: boolean = false) {
+    > 13 |     await this.locator.click({ force });
+         |                        ^
+      14 |   }
+      15 |
+      16 |   async doubleClick() {
+
+        at SelectLocator.click (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:93:58
+        at GridActions.enterGridSelectValue (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:92:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:279:25
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Data Entry › should display error state for input with invalid data" classname="tests/grid.spec.ts" time="5.853">
+</testcase>
+<testcase name="Grid › Data Entry › confirm auto-fill works correctly" classname="tests/grid.spec.ts" time="5.021">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist" classname="tests/grid.spec.ts" time="2.522">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist" classname="tests/grid.spec.ts" time="2.655">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct Period tagged from Assist" classname="tests/grid.spec.ts" time="2.666">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist" classname="tests/grid.spec.ts" time="2.908">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should edit cells using the team roster" classname="tests/grid.spec.ts" time="4.794">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should change key moment type and update grid data" classname="tests/grid.spec.ts" time="5.662">
+</testcase>
+</testsuite>
+<testsuite name="tests/onboarding.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="4" failures="0" skipped="4" time="0" errors="0">
+<testcase name="Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/statsEngine.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="12" failures="0" skipped="0" time="36.371" errors="0">
+<testcase name="Mock stats engine for speed › Filter by Offense in Phase card" classname="tests/statsEngine.spec.ts" time="3.542">
+</testcase>
+<testcase name="Mock stats engine for speed › Filter by defense in phase card" classname="tests/statsEngine.spec.ts" time="2.471">
+</testcase>
+<testcase name="Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected" classname="tests/statsEngine.spec.ts" time="3.207">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context" classname="tests/statsEngine.spec.ts" time="2.932">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context" classname="tests/statsEngine.spec.ts" time="3.549">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context" classname="tests/statsEngine.spec.ts" time="2.802">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context" classname="tests/statsEngine.spec.ts" time="2.949">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context" classname="tests/statsEngine.spec.ts" time="2.937">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context" classname="tests/statsEngine.spec.ts" time="3.277">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context" classname="tests/statsEngine.spec.ts" time="2.799">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context" classname="tests/statsEngine.spec.ts" time="3.056">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context" classname="tests/statsEngine.spec.ts" time="2.85">
+</testcase>
+</testsuite>
+</testsuites>

--- a/__tests__/java-junit.test.ts
+++ b/__tests__/java-junit.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import {JavaJunitParser} from '../src/parsers/java-junit/java-junit-parser'
 import {ParseOptions} from '../src/test-parser'
-import {getReport} from '../src/report/get-report'
+import {ReportOptions, getReport} from '../src/report/get-report'
 import {normalizeFilePath} from '../src/utils/path-utils'
 
 describe('java-junit tests', () => {
@@ -89,5 +89,118 @@ describe('java-junit tests', () => {
 
     expect(result.result === 'failed')
     expect(result.failed === 1)
+  })
+
+  it('playwright test report - all tests', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'playwright-report.xml')
+    const trackedFilesPath = path.join(__dirname, 'fixtures', 'external', 'java', 'files.txt')
+    const outputPath = path.join(__dirname, '__outputs__', 'playwright-output-all.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const trackedFiles = fs.readFileSync(trackedFilesPath, {encoding: 'utf8'}).split(/\n\r?/g)
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles
+    }
+
+    const reportOpts: ReportOptions = {
+      listSuites: 'all',
+      listTests: 'all',
+      baseUrl: '',
+      onlySummary: false
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result], reportOpts)
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+  it('playwright test report - ignore skipped tests', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'playwright-report.xml')
+    const trackedFilesPath = path.join(__dirname, 'fixtures', 'external', 'java', 'files.txt')
+    const outputPath = path.join(__dirname, '__outputs__', 'playwright-output-no-skipped.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const trackedFiles = fs.readFileSync(trackedFilesPath, {encoding: 'utf8'}).split(/\n\r?/g)
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles
+    }
+
+    const reportOpts: ReportOptions = {
+      listSuites: 'all',
+      listTests: 'non-skipped',
+      baseUrl: '',
+      onlySummary: false
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result], reportOpts)
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+  it('playwright test report - only failed', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'playwright-report.xml')
+    const trackedFilesPath = path.join(__dirname, 'fixtures', 'external', 'java', 'files.txt')
+    const outputPath = path.join(__dirname, '__outputs__', 'playwright-output-failed.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const trackedFiles = fs.readFileSync(trackedFilesPath, {encoding: 'utf8'}).split(/\n\r?/g)
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles
+    }
+
+    const reportOpts: ReportOptions = {
+      listSuites: 'failed',
+      listTests: 'failed',
+      baseUrl: '',
+      onlySummary: false
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result], reportOpts)
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+  it('playwright test report - only summary', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'playwright-report.xml')
+    const trackedFilesPath = path.join(__dirname, 'fixtures', 'external', 'java', 'files.txt')
+    const outputPath = path.join(__dirname, '__outputs__', 'playwright-output-summary.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const trackedFiles = fs.readFileSync(trackedFilesPath, {encoding: 'utf8'}).split(/\n\r?/g)
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles
+    }
+
+    const reportOpts: ReportOptions = {
+      listSuites: 'all',
+      listTests: 'all',
+      baseUrl: '',
+      onlySummary: true
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result], reportOpts)
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -313,8 +313,8 @@ class TestReporter {
             return yield this.octokit.rest.checks.update(Object.assign(Object.assign({}, requestParams), { output: Object.assign(Object.assign({}, requestParams.output), { annotations }) }));
         });
         this.octokit = github.getOctokit(this.token);
-        if (this.listSuites !== 'all' && this.listSuites !== 'failed') {
-            core.setFailed(`Input parameter 'list-suites' has invalid value`);
+        if (this.listSuites !== 'all' && this.listSuites !== 'failed' && this.listSuites !== 'non-skipped') {
+            core.setFailed(`Input parameter 'list-suites' has invalid value of ${this.listSuites}`);
             return;
         }
         if (this.listTests !== 'all' && this.listTests !== 'failed' && this.listTests !== 'none') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1715,12 +1715,6 @@ function getTestsReport(ts, runIndex, suiteIndex, options) {
     if (options.listTests === 'failed' && ts.result !== 'failed') {
         return [];
     }
-    // if (ts.result === 'skipped') {
-    //   core.info(`SKIPPED TEST LIST ${ts.name}`)
-    // }
-    // if (options.listTests === 'non-skipped' && ts.result === 'skipped') {
-    //   return []
-    // }
     const groups = ts.groups;
     if (groups.length === 0) {
         return [];
@@ -1738,7 +1732,7 @@ function getTestsReport(ts, runIndex, suiteIndex, options) {
         }
         const space = grp.name ? '  ' : '';
         for (const tc of grp.tests) {
-            if (tc.result === 'skipped') {
+            if (options.listTests === 'non-skipped' && tc.result === 'skipped') {
                 continue;
             }
             const result = getResultIcon(tc.result);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1691,13 +1691,7 @@ function getSuitesReport(tr, runIndex, options) {
             const tsNameLink = skipLink ? tsName : (0, markdown_utils_1.link)(tsName, tsAddr);
             const passed = s.passed > 0 ? `${s.passed}${markdown_utils_1.Icon.success}` : '';
             const failed = s.failed > 0 ? `${s.failed}${markdown_utils_1.Icon.fail}` : '';
-            let skipped;
-            if (options.listTests === 'non-skipped') {
-                return [tsNameLink, passed, failed, '', tsTime];
-            }
-            else {
-                skipped = s.skipped > 0 ? `${s.skipped}${markdown_utils_1.Icon.skip}` : '';
-            }
+            const skipped = s.skipped > 0 ? `${s.skipped}${markdown_utils_1.Icon.skip}` : '';
             return [tsNameLink, passed, failed, skipped, tsTime];
         }));
         sections.push(suitesTable);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1688,7 +1688,13 @@ function getSuitesReport(tr, runIndex, options) {
             const tsNameLink = skipLink ? tsName : (0, markdown_utils_1.link)(tsName, tsAddr);
             const passed = s.passed > 0 ? `${s.passed}${markdown_utils_1.Icon.success}` : '';
             const failed = s.failed > 0 ? `${s.failed}${markdown_utils_1.Icon.fail}` : '';
-            const skipped = s.skipped > 0 ? `${s.skipped}${markdown_utils_1.Icon.skip}` : '';
+            let skipped;
+            if (options.listSuites === 'non-skipped') {
+                return [tsNameLink, passed, failed, tsTime];
+            }
+            else {
+                skipped = s.skipped > 0 ? `${s.skipped}${markdown_utils_1.Icon.skip}` : '';
+            }
             return [tsNameLink, passed, failed, skipped, tsTime];
         }));
         sections.push(suitesTable);

--- a/playwright-report.xml
+++ b/playwright-report.xml
@@ -1,0 +1,472 @@
+<testsuites id="" name="" tests="60" failures="4" skipped="20" errors="0" time="59.09258599999547">
+<testsuite name="auth.setup.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="setup" tests="6" failures="0" skipped="0" time="6.702" errors="0">
+<testcase name="authenticate as classic admin" classname="auth.setup.ts" time="1.702">
+</testcase>
+<testcase name="authenticate as basketball admin" classname="auth.setup.ts" time="1.734">
+</testcase>
+<testcase name="authenticate as wrestling admin" classname="auth.setup.ts" time="1.697">
+</testcase>
+<testcase name="authenticate as onboarding admin 1" classname="auth.setup.ts" time="0.516">
+</testcase>
+<testcase name="authenticate as onboarding admin 3" classname="auth.setup.ts" time="0.527">
+</testcase>
+<testcase name="authenticate as coachAdmin" classname="auth.setup.ts" time="0.526">
+</testcase>
+</testsuite>
+<testsuite name="tests/analyze/load-video.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="3" failures="0" skipped="3" time="0" errors="0">
+<testcase name="record &quot;Time to Video&quot; when loading directly via URL › using manual timings" classname="tests/analyze/load-video.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="record &quot;Time to Video&quot; when loading directly via URL › using Performance API mark" classname="tests/analyze/load-video.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="record &quot;Time to Video&quot; when loading directly via URL › using Performance API measurement" classname="tests/analyze/load-video.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/analyze/seamless-video-playback.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="9" failures="0" skipped="9" time="0.012" errors="0">
+<testcase name="during looping playback › when clip repeats, it starts at the beginning" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="during sequential playback (&quot;Play All Clips&quot; mode) › when one clip plays through to the next, overlapping video is skipped" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Play All Clips&apos; mode, clip plays from beginning › when clicked on in navigation module" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Play All Clips&apos; mode, clip plays from beginning › with next clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Play All Clips&apos; mode, clip plays from beginning › with previous clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Loop Clips&apos; mode, clip plays from beginning › when clicked on in navigation module" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Loop Clips&apos; mode, clip plays from beginning › with next clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="in &apos;Loop Clips&apos; mode, clip plays from beginning › with previous clip button" classname="tests/analyze/seamless-video-playback.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+<property name="slow" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="rewind functions normally" classname="tests/analyze/seamless-video-playback.spec.ts" time="0.012">
+<properties>
+<property name="slow" value="">
+</property>
+<property name="slow" value="">
+</property>
+<property name="fixme" value="Implement">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/app.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="1" failures="0" skipped="1" time="0" errors="0">
+<testcase name="App › logs in and loads page" classname="tests/app.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/grid.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="25" failures="4" skipped="3" time="115.892" errors="0">
+<testcase name="Grid › Mobile Web › Athlete › should not be able to edit data" classname="tests/grid.spec.ts" time="2.968">
+</testcase>
+<testcase name="Grid › Mobile Web › Admin or Coach › should be able to edit data" classname="tests/grid.spec.ts" time="5.762">
+</testcase>
+<testcase name="Grid › Field Sets › should update displayed grid columns after editing" classname="tests/grid.spec.ts" time="9.215">
+</testcase>
+<testcase name="Grid › Field Sets › should update displayed clip preview fields after editing" classname="tests/grid.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Scout team Points" classname="tests/grid.spec.ts" time="3.15">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Opponent Rebounds" classname="tests/grid.spec.ts" time="5.091">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Steals" classname="tests/grid.spec.ts" time="4.261">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by Rebounds" classname="tests/grid.spec.ts" time="2.86">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display clips for opportunities in Period when filtered by Period" classname="tests/grid.spec.ts" time="3.501">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display clips for opportunities that end in a turnover when filtered by Turnovers" classname="tests/grid.spec.ts" time="3.721">
+</testcase>
+<testcase name="Grid › Basketball Navigation Module › should display correct moment data when filtered by 3FG Attempts" classname="tests/grid.spec.ts" time="3.282">
+</testcase>
+<testcase name="Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:202:11 should display correct data when sorting by OFF FORM column" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:202:11 › Grid › Column Sorting › AmFb Column Sets › should display correct data when sorting by OFF FORM column › Sort grid by OFF FORM in ascending order 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id^="column-header-OFF FORM-"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/table.locator.ts:12
+
+      10 |     const expectedColumnSort = this.locator.filter({ has: this.page.locator(`[data-qa-id*='${sortOrder}']`) });
+      11 |     do {
+    > 12 |       await this.locator.click();
+         |                          ^
+      13 |     } while (!expectedColumnSort.isVisible());
+      14 |   }
+      15 | }
+
+        at TableLocator.sortColumnBy (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/table.locator.ts:12:26)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:30:52
+        at GridActions.sortColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:28:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:205:27
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/table.locator.ts:12:26
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Column-Sorting-AmFb-Column-Set-8f487-ay-correct-data-when-sorting-by-OFF-FORM-column-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Column Sorting › Wrestling Column Sets › should display correct data when sorting by Period column" classname="tests/grid.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Quick Editor › should be able to edit data from quick editor as an admin or coach" classname="tests/grid.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:254:9 should open select dropdown options when pressing Spacebar in grid cell" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:254:9 › Grid › Data Entry › should open select dropdown options when pressing Spacebar in grid cell › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\'OFF FORM-column-3\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:256:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-open-select-dropdown-options-when-pressing-Spacebar-in-grid-cell-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:261:9 should be able to use keyboard to navigate horizontal grid and enter data" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:261:9 › Grid › Data Entry › should be able to use keyboard to navigate horizontal grid and enter data › double click into column OFF FORM clip number 3 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.dblclick: Target closed
+    =========================== logs ===========================
+    waiting for locator('div[data-qa-id=\'OFF FORM-column-3\']')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17
+
+      15 |
+      16 |   async doubleClick() {
+    > 17 |     await this.locator.dblclick();
+         |                        ^
+      18 |   }
+      19 |
+      20 |   async getText() {
+
+        at TextInputLocator.doubleClick (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:48:63
+        at GridActions.doubleClickIntoGridColumn (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:47:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:263:25
+
+    Pending operations:
+      - locator.dblclick at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:17:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-horizontal-grid-and-enter-data-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data" classname="tests/grid.spec.ts" time="10">
+<failure message="grid.spec.ts:277:9 should be able to use keyboard to navigate vertical grid and enter data" type="FAILURE">
+<![CDATA[  [chrome] › tests/grid.spec.ts:277:9 › Grid › Data Entry › should be able to use keyboard to navigate vertical grid and enter data › Select BUNCH from column OFF FORM list 
+
+    Test timeout of 10000ms exceeded.
+
+    Error: locator.click: Target closed
+    =========================== logs ===========================
+    waiting for locator('[data-qa-id="clip-edit-field-OFF FORM"]')
+    ============================================================
+
+       at ../../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13
+
+      11 |
+      12 |   async click(force: boolean = false) {
+    > 13 |     await this.locator.click({ force });
+         |                        ^
+      14 |   }
+      15 |
+      16 |   async doubleClick() {
+
+        at SelectLocator.click (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:93:58
+        at GridActions.enterGridSelectValue (/Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/models/actions/grid.actions.ts:92:16)
+        at /Users/connor.vidlock/Documents/GitHub/hudl-frontends/apps/watch/playwright/tests/grid.spec.ts:279:25
+
+    Pending operations:
+      - locator.click at ../../packages/playwright-shared/src/models/locators/base/base.locator.ts:13:24
+
+
+    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
+    playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+    Usage:
+
+        npx playwright show-trace playwright/test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/test-failed-1.png]]
+
+[[ATTACHMENT|test-results/tests-grid-Grid-Data-Entry-should-be-able-to-use-keyboard-to-navigate-vertical-grid-and-enter-data-chrome/trace.zip]]
+]]>
+</system-out>
+</testcase>
+<testcase name="Grid › Data Entry › should display error state for input with invalid data" classname="tests/grid.spec.ts" time="5.853">
+</testcase>
+<testcase name="Grid › Data Entry › confirm auto-fill works correctly" classname="tests/grid.spec.ts" time="5.021">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct wrestler names tagged from Assist" classname="tests/grid.spec.ts" time="2.522">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct score and points tagged from Assist" classname="tests/grid.spec.ts" time="2.655">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct Period tagged from Assist" classname="tests/grid.spec.ts" time="2.666">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should display correct Key Moments tagged from Assist" classname="tests/grid.spec.ts" time="2.908">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should edit cells using the team roster" classname="tests/grid.spec.ts" time="4.794">
+</testcase>
+<testcase name="Grid › Tagged data › Wrestling › should change key moment type and update grid data" classname="tests/grid.spec.ts" time="5.662">
+</testcase>
+</testsuite>
+<testsuite name="tests/onboarding.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="4" failures="0" skipped="4" time="0" errors="0">
+<testcase name="Grid › Onboarding › Field Visibility › should successfully display field visibility onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Onboarding › Field Visibility › Grid Hotkey Tooltip › should successfully display grid hotkey onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Onboarding › Field Visibility › Reorder Field Sets › should successfully display field reorder onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+<testcase name="Grid › Onboarding › Field Visibility › Quick Edit › should successfully display quick edit onboarding prompt" classname="tests/onboarding.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/statsEngine.spec.ts" timestamp="2024-01-26T21:29:30.878Z" hostname="chrome" tests="12" failures="0" skipped="0" time="36.371" errors="0">
+<testcase name="Mock stats engine for speed › Filter by Offense in Phase card" classname="tests/statsEngine.spec.ts" time="3.542">
+</testcase>
+<testcase name="Mock stats engine for speed › Filter by defense in phase card" classname="tests/statsEngine.spec.ts" time="2.471">
+</testcase>
+<testcase name="Mock stats engine for speed › Key stats card stats appear as expected when opponent is selected" classname="tests/statsEngine.spec.ts" time="3.207">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - FG percentage for Team in Context" classname="tests/statsEngine.spec.ts" time="2.932">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Makes for Team in Context" classname="tests/statsEngine.spec.ts" time="3.549">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 2FG Attempts for Team in Context" classname="tests/statsEngine.spec.ts" time="2.802">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Makes for Team in Context" classname="tests/statsEngine.spec.ts" time="2.949">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - 3FG Attempts for Team in Context" classname="tests/statsEngine.spec.ts" time="2.937">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Off. Rebounds for Team in Context" classname="tests/statsEngine.spec.ts" time="3.277">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Def. Rebounds for Team in Context" classname="tests/statsEngine.spec.ts" time="2.799">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Assists for Team in Context" classname="tests/statsEngine.spec.ts" time="3.056">
+</testcase>
+<testcase name="Mock stats engine for speed › Selecting a Key Stats filter updates both the Navigation Module and Insights Module cards - Steal for Team in Context" classname="tests/statsEngine.spec.ts" time="2.85">
+</testcase>
+</testsuite>
+</testsuites>

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ class TestReporter {
   constructor() {
     this.octokit = github.getOctokit(this.token)
 
-    if (this.listSuites !== 'all' && this.listSuites !== 'failed') {
+    if (this.listSuites !== 'all' && this.listSuites !== 'failed' && this.listSuites !== 'non-skipped') {
       core.setFailed(`Input parameter 'list-suites' has invalid value`)
       return
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ class TestReporter {
   readonly path = core.getInput('path', {required: true})
   readonly pathReplaceBackslashes = core.getInput('path-replace-backslashes', {required: false}) === 'true'
   readonly reporter = core.getInput('reporter', {required: true})
-  readonly listSuites = core.getInput('list-suites', {required: true}) as 'all' | 'failed'
+  readonly listSuites = core.getInput('list-suites', {required: true}) as 'all' | 'failed' | 'non-skipped'
   readonly listTests = core.getInput('list-tests', {required: true}) as 'all' | 'failed' | 'none'
   readonly maxAnnotations = parseInt(core.getInput('max-annotations', {required: true}))
   readonly failOnError = core.getInput('fail-on-error', {required: true}) === 'true'

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ class TestReporter {
     this.octokit = github.getOctokit(this.token)
 
     if (this.listSuites !== 'all' && this.listSuites !== 'failed' && this.listSuites !== 'non-skipped') {
-      core.setFailed(`Input parameter 'list-suites' has invalid value`)
+      core.setFailed(`Input parameter 'list-suites' has invalid value of ${this.listSuites}`)
       return
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,8 +39,8 @@ class TestReporter {
   readonly path = core.getInput('path', {required: true})
   readonly pathReplaceBackslashes = core.getInput('path-replace-backslashes', {required: false}) === 'true'
   readonly reporter = core.getInput('reporter', {required: true})
-  readonly listSuites = core.getInput('list-suites', {required: true}) as 'all' | 'failed' | 'non-skipped'
-  readonly listTests = core.getInput('list-tests', {required: true}) as 'all' | 'failed' | 'none'
+  readonly listSuites = core.getInput('list-suites', {required: true}) as 'all' | 'failed'
+  readonly listTests = core.getInput('list-tests', {required: true}) as 'all' | 'failed' | 'none' | 'non-skipped'
   readonly maxAnnotations = parseInt(core.getInput('max-annotations', {required: true}))
   readonly failOnError = core.getInput('fail-on-error', {required: true}) === 'true'
   readonly workDirInput = core.getInput('working-directory', {required: false})
@@ -53,12 +53,17 @@ class TestReporter {
   constructor() {
     this.octokit = github.getOctokit(this.token)
 
-    if (this.listSuites !== 'all' && this.listSuites !== 'failed' && this.listSuites !== 'non-skipped') {
+    if (this.listSuites !== 'all' && this.listSuites !== 'failed') {
       core.setFailed(`Input parameter 'list-suites' has invalid value of ${this.listSuites}`)
       return
     }
 
-    if (this.listTests !== 'all' && this.listTests !== 'failed' && this.listTests !== 'none') {
+    if (
+      this.listTests !== 'all' &&
+      this.listTests !== 'failed' &&
+      this.listTests !== 'none' &&
+      this.listTests !== 'non-skipped'
+    ) {
       core.setFailed(`Input parameter 'list-tests' has invalid value`)
       return
     }

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -190,12 +190,7 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
         const tsNameLink = skipLink ? tsName : link(tsName, tsAddr)
         const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : ''
         const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : ''
-        let skipped
-        if (options.listTests === 'non-skipped') {
-          return [tsNameLink, passed, failed, '', tsTime]
-        } else {
-          skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
-        }
+        const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
         return [tsNameLink, passed, failed, skipped, tsTime]
       })
     )

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -15,7 +15,7 @@ export interface ReportOptions {
 }
 
 const defaultOptions: ReportOptions = {
-  listSuites: 'non-skipped',
+  listSuites: 'all',
   listTests: 'all',
   baseUrl: '',
   onlySummary: false

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -8,14 +8,14 @@ import {slug} from '../utils/slugger'
 const MAX_REPORT_LENGTH = 65535
 
 export interface ReportOptions {
-  listSuites: 'all' | 'failed'
+  listSuites: 'all' | 'failed' | 'non-skipped'
   listTests: 'all' | 'failed' | 'none'
   baseUrl: string
   onlySummary: boolean
 }
 
 const defaultOptions: ReportOptions = {
-  listSuites: 'all',
+  listSuites: 'non-skipped',
   listTests: 'all',
   baseUrl: '',
   onlySummary: false
@@ -190,7 +190,12 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
         const tsNameLink = skipLink ? tsName : link(tsName, tsAddr)
         const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : ''
         const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : ''
-        const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
+        let skipped
+        if (options.listSuites === 'non-skipped') {
+          return [tsNameLink, passed, failed, tsTime]
+        } else {
+          skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
+        }
         return [tsNameLink, passed, failed, skipped, tsTime]
       })
     )

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -217,12 +217,7 @@ function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: numbe
   if (options.listTests === 'failed' && ts.result !== 'failed') {
     return []
   }
-  // if (ts.result === 'skipped') {
-  //   core.info(`SKIPPED TEST LIST ${ts.name}`)
-  // }
-  // if (options.listTests === 'non-skipped' && ts.result === 'skipped') {
-  //   return []
-  // }
+
   const groups = ts.groups
   if (groups.length === 0) {
     return []
@@ -243,7 +238,7 @@ function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: numbe
     }
     const space = grp.name ? '  ' : ''
     for (const tc of grp.tests) {
-      if (tc.result === 'skipped') {
+      if (options.listTests === 'non-skipped' && tc.result === 'skipped') {
         continue
       }
       const result = getResultIcon(tc.result)

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -8,8 +8,8 @@ import {slug} from '../utils/slugger'
 const MAX_REPORT_LENGTH = 65535
 
 export interface ReportOptions {
-  listSuites: 'all' | 'failed' | 'non-skipped'
-  listTests: 'all' | 'failed' | 'none'
+  listSuites: 'all' | 'failed'
+  listTests: 'all' | 'failed' | 'none' | 'non-skipped'
   baseUrl: string
   onlySummary: boolean
 }
@@ -191,8 +191,8 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
         const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : ''
         const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : ''
         let skipped
-        if (options.listSuites === 'non-skipped') {
-          return [tsNameLink, passed, failed, tsTime]
+        if (options.listTests === 'non-skipped') {
+          return [tsNameLink, passed, failed, '', tsTime]
         } else {
           skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
         }
@@ -217,6 +217,12 @@ function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: numbe
   if (options.listTests === 'failed' && ts.result !== 'failed') {
     return []
   }
+  // if (ts.result === 'skipped') {
+  //   core.info(`SKIPPED TEST LIST ${ts.name}`)
+  // }
+  // if (options.listTests === 'non-skipped' && ts.result === 'skipped') {
+  //   return []
+  // }
   const groups = ts.groups
   if (groups.length === 0) {
     return []
@@ -237,6 +243,9 @@ function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: numbe
     }
     const space = grp.name ? '  ' : ''
     for (const tc of grp.tests) {
+      if (tc.result === 'skipped') {
+        continue
+      }
       const result = getResultIcon(tc.result)
       sections.push(`${space}${result} ${tc.name}`)
       if (tc.error) {


### PR DESCRIPTION
This PR adds a new option 'non-skipped' to the `listTests` reportOptions. When running playwright in parallel, it was apparent that it lists all the auth steps even though the auth is shared across runners so it looks like we "skipped" 18 auth steps which can also cause some confusion. The purpose of this PR was just to hide those lines so that it doesn't cover up the value information in the report. 

I also added some additional unit tests around a real playwright output so we could more quickly make updates in the future locally. 

Before:
![Screenshot 2024-01-30 at 3 50 43 PM](https://github.com/hudl/GHA-test-reporter/assets/11067146/734f665e-cc67-4fb9-9e61-b0bf84642e8c)


After:
![Screenshot 2024-01-30 at 3 50 16 PM](https://github.com/hudl/GHA-test-reporter/assets/11067146/6e32b3a7-a165-4e1e-a418-af8572991166)
