### PR TITLE
NOTICK: Action updates

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -46,7 +46,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload test results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: __tests__/__results__/*.xml

--- a/.github/workflows/playwright-only-failed.yml
+++ b/.github/workflows/playwright-only-failed.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check dirs
         run: ls
       - name: Test reporter

--- a/.github/workflows/playwright-report-test.yml
+++ b/.github/workflows/playwright-report-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check dirs
         run: ls
       - name: Test reporter


### PR DESCRIPTION
Updates action versions used to the latest, to avoid issues around breaking changes https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/